### PR TITLE
Provide more default implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ repository = "https://github.com/NightEule5/data-streams/"
 default = ["std", "alloc"]
 std = ["num-traits/std", "simdutf8/std"]
 alloc = ["simdutf8"]
-nightly = ["nightly_specialization", "nightly_borrowed_buf"]
+nightly = ["nightly_specialization", "nightly_borrowed_buf", "nightly_uninit_slice"]
 nightly_specialization = []
 nightly_borrowed_buf = []
+nightly_uninit_slice = []
 
 [dependencies]
 bytemuck = "1.16.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ repository = "https://github.com/NightEule5/data-streams/"
 default = ["std", "alloc"]
 std = ["num-traits/std", "simdutf8/std"]
 alloc = ["simdutf8"]
+nightly = ["nightly_specialization", "nightly_borrowed_buf"]
 nightly_specialization = []
+nightly_borrowed_buf = []
 
 [dependencies]
 bytemuck = "1.16.1"

--- a/src/core_io.rs
+++ b/src/core_io.rs
@@ -1,0 +1,24 @@
+// Copyright 2024 - Strixpyrr
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "nightly_borrowed_buf")]
+
+use core::io::{BorrowedBuf, BorrowedCursor};
+use crate::{DataSink, Error, Result};
+
+impl DataSink for BorrowedBuf<'_> {
+	fn write_bytes(&mut self, buf: &[u8]) -> Result {
+		self.unfilled().write_bytes(buf)
+	}
+}
+
+impl DataSink for BorrowedCursor<'_> {
+	fn write_bytes(&mut self, buf: &[u8]) -> Result {
+		if buf.len() > self.capacity() {
+			return Err(Error::Overflow { remaining: self.capacity() - buf.len() })
+		}
+		
+		self.append(buf);
+		Ok(())
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,9 @@ pub enum Error {
 	Io(io::Error),
 	#[cfg(feature = "alloc")]
 	Utf8(Utf8Error),
+	/// A sink reached a hard storage limit, causing an overflow while writing. An
+	/// example is a mutable slice, which can't write more bytes than its length.
+	Overflow { remaining: usize },
 	End {
 		required_count: usize
 	},
@@ -97,6 +100,7 @@ impl std::error::Error for Error {
 			Self::Io(error) => Some(error),
 			#[cfg(feature = "alloc")]
 			Self::Utf8(error) => Some(error),
+			Self::Overflow { .. } |
 			Self::End { .. } => None,
 		}
 	}
@@ -109,6 +113,7 @@ impl fmt::Display for Error {
 			Self::Io(error) => fmt::Display::fmt(error, f),
 			#[cfg(feature = "alloc")]
 			Self::Utf8(error) => fmt::Display::fmt(error, f),
+			Self::Overflow { remaining } => write!(f, "sink overflowed with {remaining} bytes remaining to write"),
 			Self::End { required_count } => write!(f, "premature end-of-stream when reading {required_count} bytes"),
 		}
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@ pub use sink::DataSink;
 pub use source::{DataSource, BufferAccess};
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
 	#[cfg(feature = "std")]
 	Io(io::Error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,6 +70,7 @@ mod source;
 mod sink;
 mod vec;
 mod core_io;
+mod wrappers;
 
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly_specialization", feature(specialization))]
 #![cfg_attr(feature = "nightly_borrowed_buf", feature(core_io_borrowed_buf))]
+#![cfg_attr(feature = "nightly_uninit_slice", feature(maybe_uninit_write_slice))]
 #![allow(incomplete_features)]
 
 #[cfg(feature = "alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,10 +57,9 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "nightly_specialization", feature(specialization))]
+#![cfg_attr(feature = "nightly_borrowed_buf", feature(core_io_borrowed_buf))]
 #![allow(incomplete_features)]
 
-#[cfg(not(feature = "std"))]
-extern crate core;
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
@@ -69,6 +68,7 @@ mod std_io;
 mod source;
 mod sink;
 mod vec;
+mod core_io;
 
 #[cfg(feature = "alloc")]
 use alloc::{string::String, vec::Vec};

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -3,11 +3,17 @@
 
 use num_traits::PrimInt;
 use bytemuck::{bytes_of, Pod};
-use crate::Result;
+use crate::{Error, Result};
 
 /// A sink stream of data.
 pub trait DataSink {
 	/// Writes all bytes from `buf`. Equivalent to [`Write::write_all`].
+	/// 
+	/// # Errors
+	/// 
+	/// May return [`Overflow`](Error::Overflow) if the sink would exceed some hard
+	/// storage limit. In the case, the stream is filled completely, excluding the
+	/// overflowing bytes.
 	/// 
 	/// [`Write::write_all`]: io::Write::write_all
 	fn write_bytes(&mut self, buf: &[u8]) -> Result;

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -96,7 +96,7 @@ pub trait DataSink {
 	}
 }
 
-trait WriteSpec<T: Pod>: DataSink {
+pub(crate) trait WriteSpec<T: Pod>: DataSink {
 	fn write_int_be_spec(&mut self, value: T) -> Result
 	where T: PrimInt {
 		self.write_data_spec(value.to_be())

--- a/src/slice.rs
+++ b/src/slice.rs
@@ -62,16 +62,67 @@ impl BufferAccess for &[u8] {
 
 impl DataSink for &mut [u8] {
 	fn write_bytes(&mut self, buf: &[u8]) -> Result {
-		let len = buf.len().min(self.len());
-		// From <[_]>::take_mut
-		let (target, empty) = core::mem::take(self).split_at_mut(len);
-		*self = empty;
-		target.copy_from_slice(&buf[..len]);
-		let remaining = buf.len() - len;
-		if remaining > 0 {
-			Err(Error::Overflow { remaining })
-		} else {
-			Ok(())
-		}
+		mut_slice_write_bytes(self, buf, <[u8]>::copy_from_slice)
+	}
+
+	fn write_u8(&mut self, value: u8) -> Result {
+		use core::convert::identity;
+		mut_slice_push_u8(self, value, identity)
+	}
+
+	fn write_i8(&mut self, value: i8) -> Result {
+		self.write_u8(value as u8)
+	}
+}
+
+#[cfg(feature = "nightly_uninit_slice")]
+use core::mem::MaybeUninit;
+
+#[cfg(feature = "nightly_uninit_slice")]
+impl DataSink for &mut [MaybeUninit<u8>] {
+	fn write_bytes(&mut self, buf: &[u8]) -> Result {
+		mut_slice_write_bytes(self, buf, |t, s| { MaybeUninit::copy_from_slice(t, s); })
+	}
+
+	fn write_u8(&mut self, value: u8) -> Result {
+		mut_slice_push_u8(self, value, MaybeUninit::new)
+	}
+
+	fn write_i8(&mut self, value: i8) -> Result {
+		self.write_u8(value as u8)
+	}
+}
+
+use core::mem::take;
+
+fn mut_slice_write_bytes<T>(
+	sink: &mut &mut [T],
+	buf: &[u8],
+	copy_from_slice: impl FnOnce(&mut [T], &[u8])
+) -> Result {
+	let len = buf.len().min(sink.len());
+	// From <[_]>::take_mut
+	let (target, empty) = take(sink).split_at_mut(len);
+	*sink = empty;
+	copy_from_slice(target, &buf[..len]);
+	let remaining = buf.len() - len;
+	if remaining > 0 {
+		Err(Error::Overflow { remaining })
+	} else {
+		Ok(())
+	}
+}
+
+fn mut_slice_push_u8<T>(
+	sink: &mut &mut [T],
+	value: u8,
+	map: impl FnOnce(u8) -> T
+) -> Result {
+	if sink.is_empty() {
+		Err(Error::Overflow { remaining: 1 })
+	} else {
+		sink[0] = map(value);
+		*sink = &mut take(sink)[1..];
+		Ok(())
 	}
 }

--- a/src/std_io.rs
+++ b/src/std_io.rs
@@ -284,7 +284,7 @@ fn get_repeated_byte(repeat: &mut Repeat) -> u8 {
 	b
 }
 
-fn buf_read_skip(source: &mut (impl BufferAccess + ?Sized), count: usize) -> Result<usize> {
+fn buf_read_skip(source: &mut (impl BufferAccess + DataSource + ?Sized), count: usize) -> Result<usize> {
 	let mut skip_count = 0;
 	while skip_count < count {
 		let cur_skip_count = default_skip(&mut *source, count)?;
@@ -297,7 +297,7 @@ fn buf_read_skip(source: &mut (impl BufferAccess + ?Sized), count: usize) -> Res
 	Ok(skip_count)
 }
 
-fn buf_read_bytes<'a>(source: &mut (impl BufferAccess + Read + ?Sized), buf: &'a mut [u8]) -> Result<&'a [u8]> {
+fn buf_read_bytes<'a>(source: &mut (impl BufferAccess + DataSource + Read + ?Sized), buf: &'a mut [u8]) -> Result<&'a [u8]> {
 	use ErrorKind::Interrupted;
 
 	let mut count = 0;

--- a/src/std_io.rs
+++ b/src/std_io.rs
@@ -4,59 +4,38 @@
 
 #[cfg(feature = "alloc")]
 use alloc::string::String;
-use std::io::{BufRead, BufReader, BufWriter, ErrorKind, Read, Write};
-use crate::Result;
+use std::io::{BufRead, BufReader, BufWriter, Cursor, Empty, ErrorKind, Read, Repeat, Sink, Take, Write};
+use std::iter::repeat;
+use crate::{Error, Result};
 use crate::sink::DataSink;
-use crate::source::{BufferAccess, DataSource, default_available, default_request, default_skip};
+use crate::source::{BufferAccess, DataSource, default_skip};
 
 impl<R: Read + ?Sized> DataSource for BufReader<R> {
+	#[cfg(not(feature = "nightly_specialization"))]
 	fn available(&self) -> usize {
-		default_available(self)
+		crate::source::default_available(self)
 	}
 
+	#[cfg(not(feature = "nightly_specialization"))]
 	fn request(&mut self, count: usize) -> Result<bool> {
-		default_request(self, count)
+		crate::source::default_request(self, count)
 	}
 	
 	fn skip(&mut self, count: usize) -> Result<usize> {
-		let mut skip_count = 0;
-		while skip_count < count {
-			let cur_skip_count = default_skip(&mut *self, count)?;
-			skip_count += cur_skip_count;
-			
-			if cur_skip_count == 0 {
-				break
-			}
-		}
-		Ok(skip_count)
+		buf_read_skip(self, count)
 	}
 
 	fn read_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
-		use ErrorKind::Interrupted;
-
-		let mut count = 0;
-		loop {
-			match self.read(buf) {
-				Ok(0) => break Ok(&buf[..count]),
-				Ok(cur_count) => count += cur_count,
-				Err(err) if err.kind() == Interrupted => { }
-				Err(err) => break Err(err.into())
-			}
-		}
+		buf_read_bytes(self, buf)
 	}
 
 	fn read_exact_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
-		self.read_exact(buf)?;
-		Ok(buf)
+		buf_read_exact_bytes(self, buf)
 	}
 
 	#[cfg(feature = "alloc")]
 	fn read_utf8_to_end<'a>(&mut self, buf: &'a mut String) -> Result<&'a str> {
-		unsafe {
-			super::append_utf8(buf, |b|
-				Ok(self.read_to_end(b)?)
-			)
-		}
+		buf_read_utf8_to_end(self, buf)
 	}
 }
 
@@ -83,5 +62,268 @@ impl<W: Write + ?Sized> DataSink for BufWriter<W> {
 	fn write_bytes(&mut self, buf: &[u8]) -> Result {
 		self.write_all(buf)?;
 		Ok(())
+	}
+}
+
+impl<T: AsRef<[u8]>> DataSource for Cursor<T> {
+	#[cfg(not(feature = "nightly_specialization"))]
+	fn available(&self) -> usize { crate::source::default_available(self) }
+
+	fn request(&mut self, count: usize) -> Result<bool> {
+		Ok(self.available() >= count)
+	}
+
+	fn skip(&mut self, mut count: usize) -> Result<usize> {
+		count = count.min(self.available());
+		BufRead::consume(self, count);
+		Ok(count)
+	}
+
+	fn read_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+		let count = self.read(buf)?;
+		Ok(&buf[..count])
+	}
+
+	fn read_exact_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+		buf_read_exact_bytes(self, buf)
+	}
+
+	#[cfg(feature = "alloc")]
+	fn read_utf8_to_end<'a>(&mut self, buf: &'a mut String) -> Result<&'a str> {
+		self.read_utf8(self.available(), buf)
+	}
+}
+
+impl<T: AsRef<[u8]>> BufferAccess for Cursor<T> {
+	fn buf_capacity(&self) -> usize { cursor_as_slice(self).len() }
+
+	fn buf(&self) -> &[u8] {
+		// See Cursor::fill_buf and Cursor::split
+		let slice = cursor_as_slice(self);
+		let start = (self.position() as usize).min(slice.len());
+		&slice[start..]
+	}
+
+	fn fill_buf(&mut self) -> Result<&[u8]> {
+		Ok(self.buf()) // Nothing to read
+	}
+
+	fn clear_buf(&mut self) {
+		BufferAccess::consume(self, self.buf_capacity().min(self.position() as usize))
+	}
+
+	fn consume(&mut self, count: usize) {
+		BufRead::consume(self, count)
+	}
+}
+
+impl<T> DataSink for Cursor<T> where Self: Write {
+	fn write_bytes(&mut self, buf: &[u8]) -> Result {
+		let count = self.write(buf)?;
+		if count < buf.len() {
+			let remaining = buf.len() - count;
+			Err(Error::Overflow { remaining })
+		} else {
+			Ok(())
+		}
+	}
+}
+
+fn cursor_as_slice<T: AsRef<[u8]>>(cursor: &Cursor<T>) -> &[u8] {
+	cursor.get_ref().as_ref()
+}
+
+impl<T: BufferAccess + BufRead> DataSource for Take<T> {
+	#[cfg(not(feature = "nightly_specialization"))]
+	fn available(&self) -> usize { crate::source::default_available(self) }
+
+	#[cfg(not(feature = "nightly_specialization"))]
+	fn request(&mut self, count: usize) -> Result<bool> {
+		crate::source::default_request(self, count)
+	}
+
+	fn skip(&mut self, count: usize) -> Result<usize> {
+		buf_read_skip(self, count)
+	}
+
+	fn read_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+		buf_read_bytes(self, buf)
+	}
+
+	fn read_exact_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+		buf_read_exact_bytes(self, buf)
+	}
+
+	#[cfg(feature = "alloc")]
+	fn read_utf8_to_end<'a>(&mut self, buf: &'a mut String) -> Result<&'a str> {
+		buf_read_utf8_to_end(self, buf)
+	}
+}
+
+impl<T: BufferAccess + BufRead> BufferAccess for Take<T> {
+	fn buf_capacity(&self) -> usize { self.get_ref().buf_capacity() }
+
+	fn buf(&self) -> &[u8] {
+		let buf = self.get_ref().buf();
+		let len = (self.limit() as usize).min(buf.len());
+		&buf[..len]
+	}
+
+	fn fill_buf(&mut self) -> Result<&[u8]> {
+		Ok(BufRead::fill_buf(self)?)
+	}
+
+	fn clear_buf(&mut self) {
+		BufferAccess::consume(self, self.available())
+	}
+
+	fn consume(&mut self, count: usize) {
+		BufRead::consume(self, count)
+	}
+}
+
+macro_rules! fixed_stream_impl {
+    (impl $trait:ident for $stream:ident {
+		$($item:item)+
+	}) => {
+		impl $trait for $stream {
+			$($item)+
+		}
+		
+		impl $trait for &$stream {
+			$($item)+
+		}
+	};
+}
+
+fixed_stream_impl! {
+impl DataSource for Empty {
+	fn available(&self) -> usize { 0 }
+
+	fn request(&mut self, _: usize) -> Result<bool> {
+		Ok(false)
+	}
+
+	fn skip(&mut self, _: usize) -> Result<usize> {
+		Ok(0)
+	}
+
+	fn read_bytes<'a>(&mut self, _: &'a mut [u8]) -> Result<&'a [u8]> {
+		Ok(&[])
+	}
+
+	#[cfg(feature = "alloc")]
+	fn read_utf8<'a>(&mut self, _: usize, _: &'a mut String) -> Result<&'a str> {
+		Ok("")
+	}
+
+	#[cfg(feature = "alloc")]
+	fn read_utf8_to_end<'a>(&mut self, _: &'a mut String) -> Result<&'a str> {
+		Ok("")
+	}
+}
+}
+
+impl DataSink for Empty {
+	fn write_bytes(&mut self, _: &[u8]) -> Result { Ok(()) }
+}
+impl DataSink for &Empty {
+	fn write_bytes(&mut self, _: &[u8]) -> Result { Ok(()) }
+}
+
+impl DataSink for Sink {
+	fn write_bytes(&mut self, _: &[u8]) -> Result { Ok(()) }
+}
+impl DataSink for &Sink {
+	fn write_bytes(&mut self, _: &[u8]) -> Result { Ok(()) }
+}
+
+impl DataSource for Repeat {
+	fn available(&self) -> usize { usize::MAX }
+
+	fn request(&mut self, _: usize) -> Result<bool> {
+		Ok(true)
+	}
+
+	fn skip(&mut self, count: usize) -> Result<usize> {
+		Ok(count)
+	}
+
+	fn read_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+		let byte = get_repeated_byte(self);
+		buf.fill(byte);
+		Ok(buf)
+	}
+
+	fn read_utf8<'a>(&mut self, count: usize, buf: &'a mut String) -> Result<&'a str> {
+		let bytes @ [byte] = &[get_repeated_byte(self)];
+		if byte.is_ascii() {
+			buf.try_reserve(count)?;
+			let start = buf.len();
+			let str = unsafe {
+				// Safety: the byte is valid ASCII, which is valid UTF-8.
+				core::str::from_utf8_unchecked(&bytes[..])
+			};
+			buf.extend(repeat(str).take(count));
+			Ok(&buf[start..])
+		} else {
+			Err(Error::Ascii(*byte))
+		}
+
+	}
+
+	fn read_utf8_to_end<'a>(&mut self, _: &'a mut String) -> Result<&'a str> {
+		Err(Error::NoEnd)
+	}
+}
+
+/// A janky function which gets the private repeated byte field of [`Repeat`].
+fn get_repeated_byte(repeat: &mut Repeat) -> u8 {
+	let mut array @ [b] = [0];
+	let _ = repeat.read(&mut array).unwrap();
+	b
+}
+
+fn buf_read_skip(source: &mut (impl BufferAccess + ?Sized), count: usize) -> Result<usize> {
+	let mut skip_count = 0;
+	while skip_count < count {
+		let cur_skip_count = default_skip(&mut *source, count)?;
+		skip_count += cur_skip_count;
+
+		if cur_skip_count == 0 {
+			break
+		}
+	}
+	Ok(skip_count)
+}
+
+fn buf_read_bytes<'a>(source: &mut (impl BufferAccess + Read + ?Sized), buf: &'a mut [u8]) -> Result<&'a [u8]> {
+	use ErrorKind::Interrupted;
+
+	let mut count = 0;
+	loop {
+		match source.read(buf) {
+			Ok(0) => break Ok(&buf[..count]),
+			Ok(cur_count) => count += cur_count,
+			Err(err) if err.kind() == Interrupted => { }
+			Err(err) => break Err(err.into())
+		}
+	}
+}
+
+fn buf_read_exact_bytes<'a>(source: &mut (impl Read + ?Sized), buf: &'a mut [u8]) -> Result<&'a [u8]> {
+	match source.read_exact(&mut *buf) {
+		Ok(()) => Ok(buf),
+		Err(error) if error.kind() == ErrorKind::UnexpectedEof =>
+			Err(Error::End { required_count: buf.len() }),
+		Err(error) => Err(error.into())
+	}
+}
+
+fn buf_read_utf8_to_end<'a>(source: &mut (impl Read + ?Sized), buf: &'a mut String) -> Result<&'a str> {
+	unsafe {
+		super::append_utf8(buf, |b|
+			Ok(source.read_to_end(b)?)
+		)
 	}
 }

--- a/src/std_io.rs
+++ b/src/std_io.rs
@@ -105,7 +105,7 @@ impl<T: AsRef<[u8]>> BufferAccess for Cursor<T> {
 	}
 
 	fn fill_buf(&mut self) -> Result<&[u8]> {
-		Ok(self.buf()) // Nothing to read
+		Ok((*self).buf()) // Nothing to read
 	}
 
 	fn clear_buf(&mut self) {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -213,6 +213,13 @@ impl DataSink for VecDeque<u8> {
 	}
 }
 
+impl DataSink for String {
+	fn write_bytes(&mut self, buf: &[u8]) -> Result {
+		self.push_str(from_utf8(buf)?);
+		Ok(())
+	}
+}
+
 /// A reimplementation of the unstable [`core::str::utf8_char_width`] function.
 fn utf8_char_width(byte: u8) -> usize {
 	const UTF8_CHAR_WIDTH: &[u8; 256] = &[

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -1,0 +1,240 @@
+// Copyright 2024 - Strixpyrr
+// SPDX-License-Identifier: Apache-2.0
+
+#![cfg(feature = "alloc")]
+
+use alloc::collections::VecDeque;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::str::from_utf8_unchecked;
+use simdutf8::compat::from_utf8;
+use crate::{BufferAccess, DataSink, DataSource, Result};
+
+impl DataSource for Vec<u8> {
+	fn available(&self) -> usize { self.len() }
+
+	fn request(&mut self, count: usize) -> Result<bool> {
+		Ok(self.len() >= count)
+	}
+
+	fn skip(&mut self, mut count: usize) -> Result<usize> {
+		count = count.min(self.len());
+		self.consume(count);
+		Ok(count)
+	}
+
+	fn read_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+		let slice = self.as_slice().read_bytes(buf)?;
+		self.consume(slice.len());
+		Ok(slice)
+	}
+
+	fn read_utf8<'a>(&mut self, mut count: usize, buf: &'a mut String) -> Result<&'a str> {
+		if buf.is_empty() && count >= self.len() {
+			// If the string is empty and all bytes are being read, we can avoid
+			// copying by replacing the buffer with the vec.
+			from_utf8(self)?;
+			// Todo: This can be replaced with a SIMD version of String::from_utf8
+			//  when simdutf8#73 is implemented.
+			*buf = unsafe {
+				String::from_utf8_unchecked(core::mem::take(self))
+			};
+			return Ok(buf)
+		}
+
+		count = count.min(self.len());
+		let bytes = &self[..count];
+		let start_len = buf.len();
+		buf.push_str(from_utf8(bytes)?);
+		self.consume(count);
+		Ok(&buf[start_len..])
+	}
+
+	fn read_utf8_to_end<'a>(&mut self, buf: &'a mut String) -> Result<&'a str> {
+		self.read_utf8(self.len(), buf)
+	}
+}
+
+impl BufferAccess for Vec<u8> {
+	fn buf_capacity(&self) -> usize { self.capacity() }
+
+	fn buf(&self) -> &[u8] { self }
+
+	fn fill_buf(&mut self) -> Result<&[u8]> {
+		Ok(self) // Nothing to read
+	}
+
+	fn clear_buf(&mut self) {
+		self.clear()
+	}
+
+	fn consume(&mut self, count: usize) {
+		if count == self.len() {
+			self.clear();
+		} else {
+			self.drain(..count);
+		}
+	}
+}
+
+impl DataSink for Vec<u8> {
+	fn write_bytes(&mut self, buf: &[u8]) -> Result {
+		self.try_reserve(buf.len())?;
+		self.extend_from_slice(buf);
+		Ok(())
+	}
+
+	fn write_u8(&mut self, value: u8) -> Result {
+		self.try_reserve(1)?;
+		self.push(value);
+		Ok(())
+	}
+
+	fn write_i8(&mut self, value: i8) -> Result {
+		self.write_u8(value as u8)
+	}
+}
+
+impl DataSource for VecDeque<u8> {
+	fn available(&self) -> usize { self.len() }
+
+	fn request(&mut self, count: usize) -> Result<bool> {
+		Ok(self.len() >= count)
+	}
+
+	fn skip(&mut self, mut count: usize) -> Result<usize> {
+		count = count.min(self.len());
+		self.consume(count);
+		Ok(count)
+	}
+
+	fn read_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+		let (mut a, mut b) = self.as_slices();
+		let mut slice = &mut *buf;
+		let mut count = a.read_bytes(slice)?.len();
+		slice = &mut slice[count..];
+		count += b.read_bytes(slice)?.len();
+		self.consume(count);
+		Ok(&buf[..count])
+	}
+
+	fn read_utf8<'a>(&mut self, mut count: usize, buf: &'a mut String) -> Result<&'a str> {
+		count = count.min(self.len());
+		let start_len = buf.len();
+		match self.as_slices() {
+			(bytes, &[]) => {
+				// The deque is contiguous, validate its data in one go.
+				let bytes = &bytes[..count];
+				buf.push_str(from_utf8(bytes)?);
+				self.consume(count);
+			}
+			(mut a, mut b) => {
+				// The deque is discontiguous. Validate the first slice, then the
+				// second. If the first slice has an incomplete char, attempt to
+				// rotate it into the second slice before proceeding.
+				
+				let str_a = match from_utf8(a) {
+					Ok(str) => str,
+					Err(error) if error.error_len().is_none() => {
+						// Incomplete char. Check if the char is completed on the
+						// second slice, then rotate such that the second slice
+						// contains the completed char.
+						let char_start = error.valid_up_to();
+						let incomplete = a.len() - char_start;
+						let width = utf8_char_width(a[char_start]);
+						let remaining = width - incomplete;
+						
+						if b.len() < remaining {
+							return Err(error.into())
+						}
+						
+						self.rotate_right(incomplete);
+						(a, b) = self.as_slices();
+						assert_eq!(a.len(), char_start);
+						unsafe {
+							// Safety: this slice has been checked to contain valid
+							// UTF-8.
+							from_utf8_unchecked(a)
+						}
+					}
+					Err(error) => return Err(error.into())
+				};
+				let str_b = from_utf8(b)?;
+				buf.try_reserve(str_a.len() + str_b.len())?;
+				buf.push_str(str_a);
+				buf.push_str(str_b);
+			}
+		}
+		Ok(&buf[start_len..])
+	}
+
+	fn read_utf8_to_end<'a>(&mut self, buf: &'a mut String) -> Result<&'a str> {
+		self.read_utf8(self.len(), buf)
+	}
+}
+
+impl BufferAccess for VecDeque<u8> {
+	fn buf_capacity(&self) -> usize { self.capacity() }
+
+	fn buf(&self) -> &[u8] { self.as_slices().0 }
+
+	fn fill_buf(&mut self) -> Result<&[u8]> {
+		Ok(self.buf()) // Nothing to read
+	}
+
+	fn clear_buf(&mut self) {
+		self.clear()
+	}
+
+	fn consume(&mut self, count: usize) {
+		if self.len() == count {
+			self.clear();
+		} else {
+			self.drain(..count);
+		}
+	}
+}
+
+impl DataSink for VecDeque<u8> {
+	fn write_bytes(&mut self, buf: &[u8]) -> Result {
+		self.try_reserve(buf.len())?;
+		self.extend(buf);
+		Ok(())
+	}
+
+	fn write_u8(&mut self, value: u8) -> Result {
+		self.try_reserve(1)?;
+		self.push_back(value);
+		Ok(())
+	}
+
+	fn write_i8(&mut self, value: i8) -> Result {
+		self.write_u8(value as u8)
+	}
+}
+
+/// A reimplementation of the unstable [`core::str::utf8_char_width`] function.
+fn utf8_char_width(byte: u8) -> usize {
+	const UTF8_CHAR_WIDTH: &[u8; 256] = &[
+		// 1  2  3  4  5  6  7  8  9  A  B  C  D  E  F
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 1
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 2
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 3
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 4
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 5
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 6
+		1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 7
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 8
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 9
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // A
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // B
+		0, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // C
+		2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // D
+		3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, // E
+		4, 4, 4, 4, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // F
+	];
+	
+	UTF8_CHAR_WIDTH[byte as usize] as usize
+}
+

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -179,7 +179,7 @@ impl BufferAccess for VecDeque<u8> {
 	fn buf(&self) -> &[u8] { self.as_slices().0 }
 
 	fn fill_buf(&mut self) -> Result<&[u8]> {
-		Ok(self.buf()) // Nothing to read
+		Ok((*self).buf()) // Nothing to read
 	}
 
 	fn clear_buf(&mut self) {

--- a/src/wrappers.rs
+++ b/src/wrappers.rs
@@ -1,0 +1,232 @@
+// Copyright 2024 - Strixpyrr
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(all(feature = "alloc", not(feature = "nightly_specialization")))]
+use alloc::string::String;
+#[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+use bytemuck::Pod;
+use num_traits::PrimInt;
+use crate::{BufferAccess, DataSink, DataSource, Result};
+use crate::sink::WriteSpec;
+use crate::source::{default_read_array, ReadSpec};
+
+// Todo: DataSource couldn't be implemented for &mut <source> when specialization
+//  is enabled.
+
+// This was a PITA to get working. Did this save much time? No idea
+macro_rules! delegate_impl {
+    (with $reduced:expr;
+	$(
+	fn $name:ident($($params:tt)+)$( -> $ret:ty)?;
+	)+) => {
+		$(fn $name($($params)+)$( -> $ret)? {
+			delegate_impl!(@$reduced;$name($($params)+))
+		})+
+	};
+	(@$reduced:expr;$name:ident(&$(mut)? self$(, $param:ident: $param_ty:ty)*)) => {
+		$reduced.$name($($param),*)
+	};
+}
+
+macro_rules! impl_buf_access {
+    ($($(#[$attr:meta])?
+	impl$(<$gen:ident$(: ?$bound:ident)?>)? for $ty:ty;)+) => {
+		$(
+		$(#[$attr])?
+		impl$(<$gen: BufferAccess$( + ?$bound)?>)? BufferAccess for $ty {
+			delegate_impl! {
+				with **self;
+				fn buf_capacity(&self) -> usize;
+				fn buf(&self) -> &[u8];
+				fn fill_buf(&mut self) -> Result<&[u8]>;
+				fn clear_buf(&mut self);
+				fn consume(&mut self, count: usize);
+			}
+		})+
+	};
+}
+
+impl_buf_access! {
+	impl<S: ?Sized> for &mut S;
+	#[cfg(feature = "alloc")]
+	impl<S: ?Sized> for Box<S>;
+}
+
+macro_rules! impl_source {
+    ($($(#[$attr:meta])?
+	impl$(<$gen:ident$(: ?$bound:ident)?>)? for $ty:ty $({$($impl:item)+})?;)+) => {
+		$(
+		$(#[$attr])?
+		impl$(<$gen: DataSource$( + ?$bound)?>)? DataSource for $ty {
+			delegate_impl! {
+				with **self;
+				fn available(&self) -> usize;
+				fn request(&mut self, count: usize) -> Result<bool>;
+				fn skip(&mut self, count: usize) -> Result<usize>;
+				fn require(&mut self, count: usize) -> Result;
+				fn read_u8(&mut self) -> Result<u8>;
+				fn read_i8(&mut self) -> Result<i8>;
+				fn read_u16(&mut self) -> Result<u16>;
+				fn read_i16(&mut self) -> Result<i16>;
+				fn read_u16_le(&mut self) -> Result<u16>;
+				fn read_i16_le(&mut self) -> Result<i16>;
+				fn read_u32(&mut self) -> Result<u32>;
+				fn read_i32(&mut self) -> Result<i32>;
+				fn read_u32_le(&mut self) -> Result<u32>;
+				fn read_i32_le(&mut self) -> Result<i32>;
+				fn read_u64(&mut self) -> Result<u64>;
+				fn read_i64(&mut self) -> Result<i64>;
+				fn read_u64_le(&mut self) -> Result<u64>;
+				fn read_i64_le(&mut self) -> Result<i64>;
+				fn read_u128(&mut self) -> Result<u128>;
+				fn read_i128(&mut self) -> Result<i128>;
+				fn read_u128_le(&mut self) -> Result<u128>;
+				fn read_i128_le(&mut self) -> Result<i128>;
+				fn read_usize(&mut self) -> Result<usize>;
+				fn read_isize(&mut self) -> Result<isize>;
+				fn read_usize_le(&mut self) -> Result<usize>;
+				fn read_isize_le(&mut self) -> Result<isize>;
+			}
+
+			fn read_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+				(**self).read_bytes(buf)
+			}
+
+			fn read_exact_bytes<'a>(&mut self, buf: &'a mut [u8]) -> Result<&'a [u8]> {
+				(**self).read_exact_bytes(buf)
+			}
+
+			impl_source! { sized-impls $({$($impl)+})? }
+
+			#[cfg(feature = "alloc")]
+			fn read_utf8<'a>(&mut self, count: usize, buf: &'a mut String) -> Result<&'a str> {
+				(**self).read_utf8(count, buf)
+			}
+
+			#[cfg(feature = "alloc")]
+			fn read_utf8_to_end<'a>(&mut self, buf: &'a mut String) -> Result<&'a str> {
+				(**self).read_utf8_to_end(buf)
+			}
+		})+
+	};
+	(sized-impls {$($impl:item)+}) => { $($impl)+ };
+	(sized-impls) => {
+		fn read_array<const N: usize>(&mut self) -> Result<[u8; N]> {
+			(**self).read_array()
+		}
+
+		fn read_int<T: PrimInt + Pod>(&mut self) -> Result<T> {
+			(**self).read_int()
+		}
+
+		fn read_int_le<T: PrimInt + Pod>(&mut self) -> Result<T> {
+			(**self).read_int_le()
+		}
+
+		fn read_data<T: Pod>(&mut self) -> Result<T> {
+			(**self).read_data()
+		}
+	};
+}
+
+impl_source! {
+	// Conflicts with specialized impl, because outside crates are allowed to implement
+	// this trait for mutable references of their type; &mut S is a "foreign type" in
+	// compiler terms. I don't know a way around this issue, so we'll disable it when
+	// specialization is enabled. Fixing this down the line shouldn't be a breaking change.
+	#[cfg(not(feature = "nightly_specialization"))]
+	impl<S: ?Sized> for &mut S {
+		// No downstream implementation for these, because they're sized-only.
+		// Implement them with the defaults instead.
+
+		fn read_array<const N: usize>(&mut self) -> Result<[u8; N]> {
+			default_read_array(*self)
+		}
+
+		fn read_int<T: PrimInt + Pod>(&mut self) -> Result<T> {
+			(**self).read_int_be_spec()
+		}
+
+		fn read_int_le<T: PrimInt + Pod>(&mut self) -> Result<T> {
+			(**self).read_int_le_spec()
+		}
+
+		fn read_data<T: Pod>(&mut self) -> Result<T> {
+			(**self).read_data_spec()
+		}
+	};
+	#[cfg(all(feature = "alloc", not(feature = "nightly_specialization")))]
+	impl<S: ?Sized> for Box<S> {
+		fn read_array<const N: usize>(&mut self) -> Result<[u8; N]> {
+			default_read_array(&mut **self)
+		}
+
+		fn read_int<T: PrimInt + Pod>(&mut self) -> Result<T> {
+			(**self).read_int_be_spec()
+		}
+
+		fn read_int_le<T: PrimInt + Pod>(&mut self) -> Result<T> {
+			(**self).read_int_le_spec()
+		}
+
+		fn read_data<T: Pod>(&mut self) -> Result<T> {
+			(**self).read_data_spec()
+		}
+	};
+}
+
+macro_rules! impl_sink {
+    ($($(#[$attr:meta])?
+	impl$(<$gen:ident$(: ?$bound:ident)?>)? for $ty:ty $({$($impl:item)+})?;)+) => {
+		$(
+		$(#[$attr])?
+		impl$(<$gen: DataSink$( + ?$bound)?>)? DataSink for $ty {
+			delegate_impl! {
+				with **self;
+				fn write_bytes(&mut self, buf: &[u8]) -> Result;
+				fn write_u8(&mut self, value: u8) -> Result;
+				fn write_i8(&mut self, value: i8) -> Result;
+				fn write_u16(&mut self, value: u16) -> Result;
+				fn write_i16(&mut self, value: i16) -> Result;
+				fn write_u16_le(&mut self, value: u16) -> Result;
+				fn write_i16_le(&mut self, value: i16) -> Result;
+				fn write_u32(&mut self, value: u32) -> Result;
+				fn write_i32(&mut self, value: i32) -> Result;
+				fn write_u32_le(&mut self, value: u32) -> Result;
+				fn write_i32_le(&mut self, value: i32) -> Result;
+				fn write_u64(&mut self, value: u64) -> Result;
+				fn write_i64(&mut self, value: i64) -> Result;
+				fn write_u64_le(&mut self, value: u64) -> Result;
+				fn write_i64_le(&mut self, value: i64) -> Result;
+				fn write_u128(&mut self, value: u128) -> Result;
+				fn write_i128(&mut self, value: i128) -> Result;
+				fn write_u128_le(&mut self, value: u128) -> Result;
+				fn write_i128_le(&mut self, value: i128) -> Result;
+				fn write_usize(&mut self, value: usize) -> Result;
+				fn write_isize(&mut self, value: isize) -> Result;
+				fn write_usize_le(&mut self, value: usize) -> Result;
+				fn write_isize_le(&mut self, value: isize) -> Result;
+				fn write_utf8(&mut self, value: &str) -> Result;
+			}
+
+			fn write_int<T: PrimInt + Pod>(&mut self, value: T) -> Result {
+				(**self).write_int_be_spec(value)
+			}
+	
+			fn write_int_le<T: PrimInt + Pod>(&mut self, value: T) -> Result {
+				(**self).write_int_le_spec(value)
+			}
+	
+			fn write_data<T: Pod>(&mut self, value: T) -> Result {
+				(**self).write_data_spec(value)
+			}
+		})+
+	};
+}
+
+impl_sink! {
+	impl<S: ?Sized> for &mut S;
+	#[cfg(feature = "alloc")]
+	impl<S: ?Sized> for Box<S>;
+}


### PR DESCRIPTION
Implemented both `DataSource` and `DataSink` for:
- [`Vec<u8>`](https://doc.rust-lang.org/alloc/vec/struct.Vec.html)/[`VecDeque<u8>`](https://doc.rust-lang.org/alloc/collections/vec_deque/struct.VecDeque.html) (with `alloc` feature)
- [`std::io::Cursor`](https://doc.rust-lang.org/std/io/struct.Cursor.html) (with `std` feature)
- [`std::io::Empty`](https://doc.rust-lang.org/std/io/struct.Empty.html) (with `std` feature)
- Mutable references of these traits
- [`Box`](https://doc.rust-lang.org/alloc/boxed/struct.Box.html)ed sources and sinks (with `alloc` feature)

Implemented `DataSource` for:
- [`std::io::Take`](https://doc.rust-lang.org/std/io/struct.Take.html) (with `std` feature)
- [`std::io::Repeat`](https://doc.rust-lang.org/std/io/struct.Repeat.html) (with `std` feature)

Implemented `DataSink` for:
- `&mut [u8]`/`&mut [MaybeUninit<u8>]` (with `nightly_uninit_slice` feature)
- [`String`](https://doc.rust-lang.org/alloc/string/struct.String.html) (with `alloc` feature)
- [`std::io::Sink`](https://doc.rust-lang.org/std/io/struct.Sink.html) (with `std` feature)
- [`core::io::BorrowedBuf`](https://doc.rust-lang.org/core/io/struct.BorrowedBuf.html)/[`core::io::BorrowedCursor`](https://doc.rust-lang.org/core/io/struct.BorrowedCursor.html) (both with `nightly_borrowed_buf` feature)

Closes #8 